### PR TITLE
API SS4 compatibility in 2.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "extra": {
-    "installer-name": "starter_watea",
+    "installer-name": "watea",
     "branch-alias": {
       "dev-master": "2.x-dev"
     }

--- a/templates/Includes/Favicon.ss
+++ b/templates/Includes/Favicon.ss
@@ -1,7 +1,7 @@
 <% if $SiteConfig.FavIcon %>
   <link rel="shortcut icon" href="$SiteConfig.FavIcon.Link" />
 <% else %>
-  <link rel="shortcut icon" href="{$BaseHref}{$ThemeDir(watea)}/ico/favicon.ico" />
+  <link rel="shortcut icon" href="{$BaseHref}themes/watea/ico/favicon.ico" />
 <% end_if %>
 
 <!-- Change to rel="apple-touch-icon-precomposed" if you do not want apple chrome on icons (rounded corners and gloss) -->
@@ -9,24 +9,24 @@
   <link rel="apple-touch-icon" sizes="144x144" href="$SiteConfig.AppleTouchIcon144.Link">
   <meta name="msapplication-TileImage" content="$SiteConfig.AppleTouchIcon144.Link" />
 <% else %>
-  <link rel="apple-touch-icon" sizes="144x144" href="{$BaseHref}{$ThemeDir(watea)}/ico/apple-touch-icon-144.png">
-  <meta name="msapplication-TileImage" content="{$BaseHref}{$ThemeDir(watea)}/ico/apple-touch-icon-144.png" />
+  <link rel="apple-touch-icon" sizes="144x144" href="{$BaseHref}themes/watea/ico/apple-touch-icon-144.png">
+  <meta name="msapplication-TileImage" content="{$BaseHref}themes/watea/ico/apple-touch-icon-144.png" />
 <% end_if %>
 
 <% if $SiteConfig.AppleTouchIcon114 %>
   <link rel="apple-touch-icon" sizes="114x114" href="$SiteConfig.AppleTouchIcon114.Link">
 <% else %>
-  <link rel="apple-touch-icon" sizes="114x114" href="{$BaseHref}{$ThemeDir(watea)}/ico/apple-touch-icon-114.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="{$BaseHref}themes/watea/ico/apple-touch-icon-114.png">
 <% end_if %>
 
 <% if $SiteConfig.AppleTouchIcon72 %>
   <link rel="apple-touch-icon" sizes="72x72" href="$SiteConfig.AppleTouchIcon72.Link">
 <% else %>
-  <link rel="apple-touch-icon" sizes="72x72" href="{$BaseHref}{$ThemeDir(watea)}/ico/apple-touch-icon-72.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="{$BaseHref}themes/watea/ico/apple-touch-icon-72.png">
 <% end_if %>
 
 <% if $SiteConfig.AppleTouchIcon57 %>
   <link rel="apple-touch-icon" href="$SiteConfig.AppleTouchIcon57.Link">
 <% else %>
-  <link rel="apple-touch-icon" href="{$BaseHref}{$ThemeDir(watea)}/ico/apple-touch-icon-57.png">
+  <link rel="apple-touch-icon" href="{$BaseHref}themes/watea/ico/apple-touch-icon-57.png">
 <% end_if %>

--- a/templates/Includes/Footer.ss
+++ b/templates/Includes/Footer.ss
@@ -41,7 +41,7 @@
       <% if $SiteConfig.FooterLogoSecondary %>
         src="$SiteConfig.FooterLogoSecondary.URL"
       <% else %>
-        src="$ThemeDir(watea)/images/cwp-logo.png"
+        src="themes/watea/images/cwp-logo.png"
       <% end_if %>
 
       <% if $SiteConfig.FooterLogoSecondaryDescription %>
@@ -63,7 +63,7 @@
       <% if $SiteConfig.FooterLogo %>
         src="$SiteConfig.FooterLogo.URL"
       <% else %>
-        src="$ThemeDir(watea)/images/newzealand-government-footer.png"
+        src="themes/watea/images/newzealand-government-footer.png"
       <% end_if %>
 
       <% if $SiteConfig.FooterLogoDescription %>

--- a/templates/Layout/HomePage.ss
+++ b/templates/Layout/HomePage.ss
@@ -4,10 +4,20 @@
         <div class="row">
             <section class="col-md-7 col-md-offset-1">
                 <h1>$Title</h1>
-                <% if $Content.RichLinks %>
-                $Content.RichLinks
+                <% if $ElementalArea %>
+                    <%-- Support for content blocks, if enabled --%>
+                    <% if $ElementalArea.RichLinks %>
+                        $ElementalArea.RichLinks
+                    <% else %>
+                        $ElementalArea
+                    <% end_if %>
                 <% else %>
-                $Content
+                    <%-- CMS page content --%>
+                    <% if $Content.RichLinks %>
+                        $Content.RichLinks
+                    <% else %>
+                        $Content
+                    <% end_if %>
                 <% end_if %>
             </section>
 

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -8,7 +8,7 @@
         <% if $RSSLink %>
         <link rel='alternate' type='application/rss+xml' title='RSS' href='$RSSLink'>
         <% end_if %>
-        <link rel="stylesheet" href="$ThemeDir(watea)/dist/css/main.css">
+        <% require themedCss('dist/css/main.css') %>
         <% include Favicon %>
     </head>
     <body class="$ClassName">
@@ -23,9 +23,9 @@
         <footer class="footer-site">
             <% include Footer %>
         </footer>
-        <% require javascript('framework/thirdparty/jquery/jquery.js') %>
-        <script src="{$ThemeDir}/dist/js/main.js"></script>
-        <script src="$ThemeDir(watea)/dist/js/main.js"></script>
+        <% require javascript('//code.jquery.com/jquery-1.7.2.min.js') %>
+        <% require javascript('themes/starter/dist/js/main.js') %>
+        <% require javascript('themes/watea/dist/js/main.js') %>
         <% if $SiteConfig.GACode %>
             <script>
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -26,15 +26,6 @@
         <% require javascript('//code.jquery.com/jquery-1.7.2.min.js') %>
         <% require javascript('themes/starter/dist/js/main.js') %>
         <% require javascript('themes/watea/dist/js/main.js') %>
-        <% if $SiteConfig.GACode %>
-            <script>
-                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-                ga('create', '$SiteConfig.GACode', 'auto');
-                ga('send', 'pageview');
-            </script>
-        <% end_if %>
+        <% include GoogleAnalytics %>
     </body>
 </html>


### PR DESCRIPTION
Summary of changes:

* Use "themed requirements" API for template requirements
* Rename installer name from "starter_watea" to just "watea" - SS4 will treat Wātea as a standalone theme rather than a subtheme
* Enable content blocks in page templates (dnadesign/silverstripe-elemental) if installed
* Switch to inheriting the GoogleAnalytics include from starter theme rather than include it in Page template

## Blockers

- [x] https://github.com/silverstripe/cwp-starter-theme/pull/2