### PR TITLE
Replace references to GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CWP Wātea theme
 
-This theme is a [subtheme](https://docs.silverstripe.org/en/3/developer_guides/templates/themes) of the [Starter theme](https://gitlab.cwp.govt.nz/cwp/starter-theme). It provides a more visually appealing example for starting a theme for a CWP website.
+This theme is a [subtheme](https://docs.silverstripe.org/en/3/developer_guides/templates/themes) of the [Starter theme](https://github.com/silverstripe/cwp-starter-theme). It provides a more visually appealing example for starting a theme for a CWP website.
 
 ![Screenshot](docs/images/screenshot.jpg)
 
@@ -14,9 +14,9 @@ composer require cwp/watea-theme
 
 ## Documentation
 
-You can find documentation on how to use this theme in the CWP Developer Documentation: [Using the Wātea theme](https://gitlab.cwp.govt.nz/cwp/cwp/blob/1.6/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md).
+You can find documentation on how to use this theme in the CWP Developer Documentation: [Using the Wātea theme](https://github.com/silverstripe/cwp/blob/master/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md).
 
-You may also find the documentation for the Starter theme useful: [Customising the starter theme](https://gitlab.cwp.govt.nz/cwp/cwp/blob/1.6/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md).
+You may also find the documentation for the Starter theme useful: [Customising the starter theme](https://github.com/silverstripe/cwp/blob/master/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md).
 
 ## Requirements
 
@@ -25,7 +25,7 @@ You may also find the documentation for the Starter theme useful: [Customising t
 
 ## Suggested module
 
-The [agency-extensions](https://gitlab.cwp.govt.nz/cwp/agency-extensions) module provides additional functionality to the CMS for agency-style websites.
+The [agency-extensions](https://github.com/silverstripe/cwp-agencyextensions) module provides additional functionality to the CMS for agency-style websites.
 
 ### Development requirements
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://gitlab.cwp.govt.nz/cwp/watea-theme.git"
+    "url": "https://github.com/silverstripe/cwp-watea-theme"
   },
   "license": "BSD-3-Clause",
   "dependencies": {


### PR DESCRIPTION
Replaces links to GitLab repos for the watea theme, the starter theme and the agency extensions module with GitHub ones. Resolves #1 