### PR TITLE
FIX Only show "Export PDF" text for screen readers

### DIFF
--- a/templates/Includes/PageUtilities.ss
+++ b/templates/Includes/PageUtilities.ss
@@ -17,7 +17,9 @@
                         for configuration instructions --%>
                         <%-- <% if $PdfLink %>
                             <li>
-                                <a href="$PdfLink" class="btn btn-link  fa fa-file-pdf-o"><%t CWP.Home.PDF "Export PDF" %></a>
+                                <a href="$PdfLink" class="btn btn-link fa fa-file-pdf-o">
+                                    <span class="sr-only"><%t CWP.Home.PDF "Export PDF" %></span>
+                                </a>
                             </li>
                         <% end_if %> --%>
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/5170590/35537984-2b6bd7b4-05b1-11e8-82e8-da5aee163b38.png)

After:

![image](https://user-images.githubusercontent.com/5170590/35538012-409fd5ae-05b1-11e8-8d23-db48b7b4b1c4.png)
