### PR TITLE
FIX expose public assets to the public for public/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,12 @@
     "installer-name": "watea",
     "branch-alias": {
       "dev-master": "2.x-dev"
-    }
+    },
+    "expose": [
+      "dist",
+      "ico",
+      "images"
+    ]
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
SilverStripe core 4.1 enables the option of a subdirectory as the docroot
of the web server - "public/". To enable items that were previously within
the docroot (such as themes/watea/images, etc.) we must use the new
"expose" extension with composer.