### PR TITLE
FIX Starter theme now correctly resolves the favicon image URLs for the frontend

### DIFF
--- a/templates/Includes/Favicon.ss
+++ b/templates/Includes/Favicon.ss
@@ -1,7 +1,7 @@
 <% if $SiteConfig.FavIcon %>
   <link rel="shortcut icon" href="$SiteConfig.FavIcon.Link" />
 <% else %>
-  <link rel="shortcut icon" href="{$BaseHref}themes/watea/ico/favicon.ico" />
+  <link rel="shortcut icon" href="$resourceURL('themes/watea/ico/favicon.ico')" />
 <% end_if %>
 
 <!-- Change to rel="apple-touch-icon-precomposed" if you do not want apple chrome on icons (rounded corners and gloss) -->
@@ -9,24 +9,24 @@
   <link rel="apple-touch-icon" sizes="144x144" href="$SiteConfig.AppleTouchIcon144.Link">
   <meta name="msapplication-TileImage" content="$SiteConfig.AppleTouchIcon144.Link" />
 <% else %>
-  <link rel="apple-touch-icon" sizes="144x144" href="{$BaseHref}themes/watea/ico/apple-touch-icon-144.png">
-  <meta name="msapplication-TileImage" content="{$BaseHref}themes/watea/ico/apple-touch-icon-144.png" />
+  <link rel="apple-touch-icon" sizes="144x144" href="$resourceURL('themes/watea/ico/apple-touch-icon-144.png')">
+  <meta name="msapplication-TileImage" content="$resourceURL('themes/watea/ico/apple-touch-icon-144.png')">
 <% end_if %>
 
 <% if $SiteConfig.AppleTouchIcon114 %>
   <link rel="apple-touch-icon" sizes="114x114" href="$SiteConfig.AppleTouchIcon114.Link">
 <% else %>
-  <link rel="apple-touch-icon" sizes="114x114" href="{$BaseHref}themes/watea/ico/apple-touch-icon-114.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="$resourceURL('themes/watea/ico/apple-touch-icon-114.png')">
 <% end_if %>
 
 <% if $SiteConfig.AppleTouchIcon72 %>
   <link rel="apple-touch-icon" sizes="72x72" href="$SiteConfig.AppleTouchIcon72.Link">
 <% else %>
-  <link rel="apple-touch-icon" sizes="72x72" href="{$BaseHref}themes/watea/ico/apple-touch-icon-72.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="$resourceURL('themes/watea/ico/apple-touch-icon-72.png')">
 <% end_if %>
 
 <% if $SiteConfig.AppleTouchIcon57 %>
   <link rel="apple-touch-icon" href="$SiteConfig.AppleTouchIcon57.Link">
 <% else %>
-  <link rel="apple-touch-icon" href="{$BaseHref}themes/watea/ico/apple-touch-icon-57.png">
+  <link rel="apple-touch-icon" href="$resourceURL('themes/watea/ico/apple-touch-icon-57.png')">
 <% end_if %>


### PR DESCRIPTION
Resolves https://github.com/silverstripe/cwp-watea-theme/issues/31.

Matching starter theme PR at https://github.com/silverstripe/cwp-starter-theme/pull/69

Needs merging up afterwards