### PR TITLE
FIX Add aria-label to Language selector for narrow viewports

### DIFF
--- a/templates/Includes/LanguageSelector.ss
+++ b/templates/Includes/LanguageSelector.ss
@@ -1,6 +1,6 @@
 <% if $Locales %>
     <div class="dropdown float-right language-selector" id="header-language-toggle">
-        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Language selector">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="<%t CWPLanguageSelector.LANGUAGE_SELECTOR "Language selector" %>">
             <i class="fa fa-language" aria-hidden="true"></i>
             <span class="d-none d-sm-inline-block">
                 $SelectedLanguage

--- a/templates/Includes/LanguageSelector.ss
+++ b/templates/Includes/LanguageSelector.ss
@@ -1,6 +1,6 @@
 <% if $Locales %>
     <div class="dropdown float-right language-selector" id="header-language-toggle">
-        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Language selector">
             <i class="fa fa-language" aria-hidden="true"></i>
             <span class="d-none d-sm-inline-block">
                 $SelectedLanguage


### PR DESCRIPTION
**High priority:**
In narrow viewports, the language selector button has no accessible name.
![image](https://user-images.githubusercontent.com/24258161/60303623-0252de80-998b-11e9-8cc1-147ac381cfab.png)
**Impact:** Without a discernible, accessible textual name, there is no way to describe to screen reader users the purpose of a button. When there is no name, there is no clear description of the destination, purpose, function or action for the non-text content when it is intended to be used as a control.
**Solution:** Add an aria-label to the button.