### PR TITLE
FIX Add aria-labels and remove redundant span and title attributes

### DIFF
--- a/templates/Includes/Footer.ss
+++ b/templates/Includes/Footer.ss
@@ -13,13 +13,13 @@
         <% if $SiteConfig.FacebookURL || $SiteConfig.TwitterUsername %>
             <div class="footer-social-links col-auto order-1 order-md-3" role="complementary">
                 <% if $SiteConfig.FacebookURL %>
-                    <a class="fa fa-facebook" href="http://www.facebook.com/$SiteConfig.FacebookURL" title='<%t CWP.Footer.FollowOnFacebook "Follow us on Facebook" %>'>
+                    <a class="fa fa-facebook" href="http://www.facebook.com/$SiteConfig.FacebookURL">
                         <span class="sr-only"><%t CWP.Footer.FollowOnFacebook "Follow us on Facebook" %></span>
                     </a>
                 <% end_if %>
 
                 <% if $SiteConfig.TwitterUsername %>
-                    <a class="fa fa-twitter" href="http://www.twitter.com/$SiteConfig.TwitterUsername" title='<%t CWP.Footer.FollowOnTwitter "Follow us on Twitter" %>'>
+                    <a class="fa fa-twitter" href="http://www.twitter.com/$SiteConfig.TwitterUsername">
                         <span class="sr-only"><%t CWP.Footer.FollowOnTwitter "Follow us on Twitter" %></span>
                     </a>
                 <% end_if %>

--- a/templates/Includes/PageUtilities.ss
+++ b/templates/Includes/PageUtilities.ss
@@ -8,8 +8,8 @@
                     <% end_if %>
                     <ul class="list-inline float-right page-utilities-actions">
                         <li>
-                            <a href="#" class="btn btn-link fa fa-print" onclick="window.print(); return false;">
-                                <span class="sr-only"><%t SilverStripe\\Forms\\GridField\\GridField.Print "Print" %></span>
+                            <a href="#" class="btn btn-link" onclick="window.print(); return false;" aria-label="<%t SilverStripe\\Forms\\GridField\\GridField.Print "Print" %>">
+                                <i class="fa fa-print" aria-hidden="true"></i>
                             </a>
                         </li>
 
@@ -17,8 +17,8 @@
                         for configuration instructions --%>
                         <% if $PdfLink %>
                             <li>
-                                <a href="$PdfLink" class="btn btn-link fa fa-file-pdf-o">
-                                    <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.PDF "Export PDF" %></span>
+                                <a href="$PdfLink" class="btn btn-link" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.PDF "Export PDF" %>">
+                                    <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
                                 </a>
                             </li>
                         <% end_if %>
@@ -26,26 +26,26 @@
                         <% if $ClassName == HomePage %>
                             <% if $AtomLink %>
                                 <li>
-                                    <a href="$AtomLink" class="btn btn-link fa fa-rss">
-                                        <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                    <a href="$AtomLink" class="btn btn-link" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                        <i class="fa fa-rss" aria-hidden="true"></i>
                                     </a>
                                 </li>
                             <% else_if $RSSLink %>
                                 <li>
-                                    <a href="$RSSLink" class="btn btn-link fa fa-rss">
-                                        <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                    <a href="$RSSLink" class="btn btn-link" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                        <i class="fa fa-rss" aria-hidden="true"></i>
                                     </a>
                                 </li>
                             <% else_if $DefaultAtomLink %>
                                 <li>
-                                    <a href="$DefaultAtomLink" class="btn btn-link fa fa-rss">
-                                        <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                    <a href="$DefaultAtomLink" class="btn btn-link" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                        <i class="fa fa-rss" aria-hidden="true"></i>
                                     </a>
                                 </li>
                             <% else_if $DefaultRSSLink %>
                                 <li>
-                                    <a href="$DefaultRSSLink" class="btn btn-link fa fa-rss">
-                                        <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                    <a href="$DefaultRSSLink" class="btn btn-link" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                        <i class="fa fa-rss" aria-hidden="true"></i>
                                     </a>
                                 </li>
                             <% end_if %>
@@ -53,8 +53,8 @@
 
                         <% if $ClassName == CWP\\CWP\\PageTypes\\NewsHolder || $ClassName == CWP\\CWP\\PageTypes\\EventsHolder || $ClassName == SilverStripe\\Blog\\Model\\Blog %>
                             <li>
-                                <a href="#subscribe" class="btn btn-link fa fa-rss">
-                                    <span class="sr-only"><%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %></span>
+                                <a href="#subscribe" class="btn btn-link" aria-label="<%t CWP\\CWP\\PageTypes\\BaseHomePage.Subscribe "Subscribe" %>">
+                                    <i class="fa fa-rss" aria-hidden="true"></i>
                                 </a>
                             </li>
                         <% end_if %>


### PR DESCRIPTION
**Medium priority:** The "Print", "Subscribe", "Facebook", "Twitter" and external link icon fonts are included as a unicode value in the accessible name.
![image](https://user-images.githubusercontent.com/24258161/60305243-14834b80-9990-11e9-9975-5d6feef4c808.png)
**Impact:** If the icon is not hidden from assistive technology users, the meaningless unicode value will be announced, which may confuse users.
**Solution:** Add an aria-label to the links to provide the accessible name and remove the redundant <span> and title elements.

**NOTE:** This PR excludes the external link icon font, we will still need to address this issue.

**Low priority**:
The title attribute on the "Facebook" and "Twitter" icons is causing an unnecessary duplication of the accessible name of the link.
![image](https://user-images.githubusercontent.com/24258161/60305699-90ca5e80-9991-11e9-8e1f-697730e65eb5.png)
**Impact:** Users who rely on the markup to understand the purpose of an image or graphic will be forced to listen twice to the accessible name.
**Solution:** Remove the redundant title attribute, thereby leaving the span
text to serve as the accessible name.