### PR TITLE
FIX Add tabindex to focus the results notification message

### DIFF
--- a/templates/Layout/Page_results.ss
+++ b/templates/Layout/Page_results.ss
@@ -20,7 +20,7 @@
                             <% end_if %>
                             <div class="row">
                                 <div class="col-sm-12 col-md-8">
-                                    <p class="lead search-results__message">
+                                    <p class="lead search-results__message" tabindex="-1">
                                         <% if $Original %>
                                             <%t CWP_Search.ShowingResultsInsteadFor 'Showing results for "{query}" instead' query=$Query.XML %>
                                         <% else %>


### PR DESCRIPTION
**Medium priority:** When a user submits a site search, focus is sent back up to the top of the page rather than to the results notification message.
![image](https://user-images.githubusercontent.com/24258161/60312061-ee6ca400-99ad-11e9-9b42-ee7ffc02b96f.png)
**Impact:** The results of a search is clear to sighted users but for non- sighted users, who would have to manually search for the results. Sending focus to the results notification helps to orientate and confirm user actions.
**Solution:** On activation or submission of the search button, focus should be sent to the results element that confirms the user action.
