### PR TITLE
NEW Improve ARIA Landmarks by adjusting role attributes

### DIFF
--- a/templates/Includes/Footer.ss
+++ b/templates/Includes/Footer.ss
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="row justify-content-between">
         <% if $Footer.Children %>
-            <nav class="footer-nav-links col-auto order-2" aria-label="Footer navigation">
+            <nav class="footer-nav-links col-auto order-2" aria-label="<%t CWP_Theme.FOOTER 'Footer' %>" role="navigation">
                 <% loop $Footer.Children %>
                     <a href="$Link" class="$LinkingMode <% if $LinkingMode = current %> active<% end_if %>">
                         $MenuTitle.XML
@@ -11,7 +11,7 @@
         <% end_if %>
 
         <% if $SiteConfig.FacebookURL || $SiteConfig.TwitterUsername %>
-            <div class="footer-social-links col-auto order-1 order-md-3" role="complementary">
+            <div class="footer-social-links col-auto order-1 order-md-3">
                 <% if $SiteConfig.FacebookURL %>
                     <a class="fa fa-facebook" href="http://www.facebook.com/$SiteConfig.FacebookURL" title='<%t CWP.Footer.FollowOnFacebook "Follow us on Facebook" %>'>
                         <span class="sr-only"><%t CWP.Footer.FollowOnFacebook "Follow us on Facebook" %></span>

--- a/templates/Includes/MainNav.ss
+++ b/templates/Includes/MainNav.ss
@@ -1,5 +1,5 @@
 <div class="main-nav">
-    <nav class="navbar navbar-expand-md navbar-dark" aria-label="<%t CWP_Theme.MAIN_NAVIGATION 'Main navigation' %>">
+    <nav class="navbar navbar-expand-md navbar-dark" aria-label="<%t CWP_Theme.MAIN 'Main' %>" role="navigation">
         <div class="container">
             <div class="collapse navbar-collapse" id="navbar-collapse">
                 <div class="d-block d-md-none border-bottom border-top">

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -19,15 +19,15 @@
         <% if $SiteConfig.FooterBackground %>theme-footer-{$SiteConfig.FooterBackground}<% end_if %>
         <% if $SiteConfig.AccentColor %>theme-accent-{$SiteConfig.AccentColor}<% end_if %>
         <% if $SiteConfig.TextLinkColor %>theme-link-{$SiteConfig.TextLinkColor}<% end_if %>">
-        <header class="header">
+        <header class="header" role="banner">
             <% include Header %>
             <% include MainNav %>
         </header>
-        <main id="main" class="main">
+        <main id="main" class="main" role="main">
             $Layout
         </main>
         <% include PageShowcase %>
-        <footer class="footer-site">
+        <footer class="footer-site" role="contentinfo">
             <% include Footer %>
         </footer>
         <% require javascript('//code.jquery.com/jquery-3.3.1.min.js') %>


### PR DESCRIPTION
Based on accessibility feedback:

> - The main landmark should be at top level but there is a main landmark contained within another main landmark. It is best practice to have one main landmark.
> - Aside / complimentary content is ancillary content to the main theme of a document or page and should therefore be at top level, but it is nested within another landmark.
> - "Navigation" has been included in the aria-labels for the main and footer `<nav>` landmarks which causes unnecessary duplication within their accessible name
> - It is a best practice to use both HTML5 and ARIA landmarks to ensure all content is contained within a navigational region. In HTML5, you should use elements like `<header>`, `<nav>`, `<main>`, and `<footer>`. Their ARIA counterparts are `role="banner"`, `role="navigation"`, `role="main"`, and `role="contentinfo"`, in that order.