### PR TITLE
FIX Remove btn btn link to remove default bootstrap styling from navbar-caret

### DIFF
--- a/templates/Includes/MainNav.ss
+++ b/templates/Includes/MainNav.ss
@@ -13,7 +13,7 @@
                             <a href="$Link" <% if $LinkingMode = current %>aria-current="page"<% end_if %> class="nav-link $LinkingMode">$MenuTitle.XML</a>
 
                             <% if $Children %>
-                                <button class="btn btn-link float-right navbar-touch-caret" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">
+                                <button class="float-right navbar-touch-caret" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">
                                     <span class="sr-only"><%t CWP_Theme.DISPLAY_SUBMENU_PAGES "Display {count} submenu pages" count=$MenuTitle.XML %></span>
                                     <i class="fa fa-caret-down" aria-hidden="true"></i>
                                 </button>


### PR DESCRIPTION
Fixes #66