### PR TITLE
FIX - 3.0 - Use https for requesting jquery

### DIFF
--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -30,7 +30,7 @@
         <footer class="footer-site" role="contentinfo">
             <% include Footer %>
         </footer>
-        <% require javascript('//code.jquery.com/jquery-3.4.1.min.js') %>
+        <% require javascript('https://code.jquery.com/jquery-3.4.1.min.js') %>
         <% require javascript('themes/starter/dist/js/main.js') %>
         <% require javascript('themes/watea/dist/js/main.js') %>
         <% include GoogleAnalytics %>


### PR DESCRIPTION
This is because https://observatory.mozilla.org complains about using protocol-relative URLs via src="//..."

Resolves https://github.com/silverstripe/cwp-watea-theme/issues/114