### PR TITLE
FIX Update jQuery to 3.5.1 via inlined dep in starter theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["silverstripe", "theme", "cwp"],
   "license": "BSD-3-Clause",
   "require": {
-    "cwp/starter-theme": "^3.0@dev",
+    "cwp/starter-theme": "^3.2@dev",
     "cwp/agency-extensions": "^2.0"
   },
   "extra": {

--- a/templates/Page.ss
+++ b/templates/Page.ss
@@ -8,7 +8,7 @@
         <% if $RSSLink %>
         <link rel='alternate' type='application/rss+xml' title='RSS' href='$RSSLink'>
         <% end_if %>
-        <% require themedCss('dist/css/main.css') %>
+        <% require themedCSS('dist/css/main.css') %>
         <% include Favicon %>
     </head>
     <body class="$ClassName
@@ -30,7 +30,7 @@
         <footer class="footer-site" role="contentinfo">
             <% include Footer %>
         </footer>
-        <% require javascript('https://code.jquery.com/jquery-3.4.1.min.js') %>
+        <% require javascript('themes/starter/dist/js/jquery.min.js') %>
         <% require javascript('themes/starter/dist/js/main.js') %>
         <% require javascript('themes/watea/dist/js/main.js') %>
         <% include GoogleAnalytics %>


### PR DESCRIPTION
Wātea 3.1.0 will require Starter 3.2.0 to ensure that the inlined version of jQuery is present.

Related: silverstripe/cwp-starter-theme#188