### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "cwp/starter-theme": "3.3.x-dev",
-        "cwp/agency-extensions": "2.7.x-dev"
+        "cwp/starter-theme": "^3.2@dev",
+        "cwp/agency-extensions": "^2.0"
     },
     "extra": {
         "installer-name": "watea",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

See https://github.com/silverstripe/cwp-watea-theme/commit/7c6d18b66188dd6c5f1e8e1012f3c10aa807336c

## Issue
- https://github.com/silverstripe/.github/issues/33